### PR TITLE
Standardize configuration usage across modules

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,61 +1,104 @@
-"""
-Configuration management module for the Meeting Assistant application.
+"""Configuration management module for the Meeting Assistant application."""
 
-This module centralizes configuration logic and provides a clean interface
-for accessing environment variables and application settings.
-"""
+from __future__ import annotations
 
 import os
-from typing import Optional
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+from dotenv import load_dotenv
+
+# Ensure values from a local .env file are available before configuration is built
+load_dotenv()
 
 
 @dataclass
 class UploadConfig:
     """Configuration for file uploads."""
+
     max_file_size_mb: int
     upload_dir: str
-    allowed_extensions: tuple
-    
+    allowed_extensions: Tuple[str, ...]
+
     @property
     def max_file_size_bytes(self) -> int:
-        """Get max file size in bytes."""
+        """Return the maximum upload size in bytes."""
         return self.max_file_size_mb * 1024 * 1024
-    
-    def __post_init__(self):
-        """Ensure upload directory exists."""
+
+    def __post_init__(self) -> None:
+        """Ensure the upload directory exists."""
         Path(self.upload_dir).mkdir(parents=True, exist_ok=True)
 
 
 @dataclass
 class ModelConfig:
-    """Configuration for AI models."""
+    """Configuration for AI model defaults and providers."""
+
     default_whisper_model: str
     default_chat_model: str
     default_analysis_model: str
+    local_chat_model: str
+    local_analysis_model: str
     default_max_tokens: int
     default_temperature: float
     ollama_base_url: str
 
 
 @dataclass
+class APIConfig:
+    """Centralised storage for API credentials."""
+
+    _openai_api_key: Optional[str] = None
+    _huggingface_token: Optional[str] = None
+    extra_keys: Dict[str, str] = field(default_factory=dict)
+
+    def get(self, name: Optional[str]) -> Optional[str]:
+        """Return a credential by its environment variable style name."""
+        if not name:
+            return None
+
+        normalized = name.upper()
+        if normalized in self.extra_keys:
+            return self.extra_keys[normalized]
+
+        known = {
+            "OPENAI_API_KEY": self._openai_api_key,
+            "HUGGINGFACE_TOKEN": self._huggingface_token,
+        }
+        return known.get(normalized) or os.getenv(normalized)
+
+    @property
+    def openai_api_key(self) -> Optional[str]:
+        """Convenience accessor for the OpenAI API key."""
+        return self.get("OPENAI_API_KEY")
+
+    @property
+    def huggingface_token(self) -> Optional[str]:
+        """Convenience accessor for the Hugging Face token."""
+        return self.get("HUGGINGFACE_TOKEN")
+
+
+@dataclass
 class DatabaseConfig:
-    """Database configuration."""
+    """Database connection settings."""
+
     url: str
     echo: bool = False
 
 
 @dataclass
 class CeleryConfig:
-    """Celery configuration."""
+    """Celery broker/back-end configuration."""
+
     broker_url: str
     result_backend: str
 
 
 @dataclass
 class AppConfig:
-    """Main application configuration."""
+    """Main application configuration object."""
+
     title: str
     description: str
     version: str
@@ -64,50 +107,67 @@ class AppConfig:
     model: ModelConfig
     database: DatabaseConfig
     celery: CeleryConfig
+    api: APIConfig
+
+    def get_api_key(self, name: Optional[str]) -> Optional[str]:
+        """Proxy helper for fetching an API key from :class:`APIConfig`."""
+        return self.api.get(name)
 
 
 def get_upload_config() -> UploadConfig:
-    """Get upload configuration from environment variables."""
+    """Build the :class:`UploadConfig` from environment variables."""
+    allowed = tuple(
+        ext.strip()
+        for ext in os.getenv("ALLOWED_EXTENSIONS", ".wav,.mp3,.mp4,.m4a,.flac").split(",")
+        if ext.strip()
+    )
     return UploadConfig(
         max_file_size_mb=int(os.getenv("MAX_FILE_SIZE_MB", "3000")),
         upload_dir=os.getenv("UPLOAD_DIR", "uploads"),
-        allowed_extensions=tuple(
-            ext.strip() 
-            for ext in os.getenv("ALLOWED_EXTENSIONS", ".wav,.mp3,.mp4,.m4a,.flac").split(",")
-        )
+        allowed_extensions=allowed,
     )
 
 
 def get_model_config() -> ModelConfig:
-    """Get model configuration from environment variables."""
+    """Build the :class:`ModelConfig` from environment variables."""
     return ModelConfig(
         default_whisper_model=os.getenv("DEFAULT_WHISPER_MODEL", "base"),
         default_chat_model=os.getenv("DEFAULT_CHAT_MODEL", "gpt-4o-mini"),
         default_analysis_model=os.getenv("DEFAULT_ANALYSIS_MODEL", "gpt-4o-mini"),
+        local_chat_model=os.getenv("DEFAULT_LOCAL_CHAT_MODEL", "llama3"),
+        local_analysis_model=os.getenv("DEFAULT_LOCAL_ANALYSIS_MODEL", "llama3"),
         default_max_tokens=int(os.getenv("DEFAULT_MAX_TOKENS", "4000")),
         default_temperature=float(os.getenv("DEFAULT_TEMPERATURE", "0.1")),
-        ollama_base_url=os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+        ollama_base_url=os.getenv("OLLAMA_BASE_URL", "http://localhost:11434"),
+    )
+
+
+def get_api_config() -> APIConfig:
+    """Build the :class:`APIConfig` from environment variables."""
+    return APIConfig(
+        _openai_api_key=os.getenv("OPENAI_API_KEY"),
+        _huggingface_token=os.getenv("HUGGINGFACE_TOKEN"),
     )
 
 
 def get_database_config() -> DatabaseConfig:
-    """Get database configuration from environment variables."""
+    """Build the :class:`DatabaseConfig` from environment variables."""
     return DatabaseConfig(
         url=os.getenv("DATABASE_URL", "sqlite:///./app.db"),
-        echo=os.getenv("DATABASE_ECHO", "false").lower() == "true"
+        echo=os.getenv("DATABASE_ECHO", "false").lower() == "true",
     )
 
 
 def get_celery_config() -> CeleryConfig:
-    """Get Celery configuration from environment variables."""
+    """Build the :class:`CeleryConfig` from environment variables."""
     return CeleryConfig(
         broker_url=os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0"),
-        result_backend=os.getenv("CELERY_RESULT_BACKEND", "redis://localhost:6379/0")
+        result_backend=os.getenv("CELERY_RESULT_BACKEND", "redis://localhost:6379/0"),
     )
 
 
 def get_app_config() -> AppConfig:
-    """Get complete application configuration."""
+    """Construct the aggregate :class:`AppConfig`."""
     return AppConfig(
         title="Meeting Assistant API",
         description="Enhanced API for transcribing and analyzing meetings with export capabilities.",
@@ -116,9 +176,10 @@ def get_app_config() -> AppConfig:
         upload=get_upload_config(),
         model=get_model_config(),
         database=get_database_config(),
-        celery=get_celery_config()
+        celery=get_celery_config(),
+        api=get_api_config(),
     )
 
 
-# Global configuration instance
+# Global configuration instance used across the application
 config = get_app_config()

--- a/backend/app/core/diarization.py
+++ b/backend/app/core/diarization.py
@@ -5,6 +5,7 @@ import logging
 from .utils import get_file_metadata
 from .cache import cache_result, get_file_hash
 from .retry import retry_gpu_operation
+from .config import config
 
 # Setup logging
 logger = logging.getLogger(__name__)
@@ -80,9 +81,9 @@ def diarize_audio(audio_path: str, num_speakers: Optional[int] = None, progress_
     file_hash = get_file_hash(audio_path)
     logger.info(f"File hash: {file_hash}")
 
-    auth_token = os.getenv("HUGGINGFACE_TOKEN")
+    auth_token = config.api.get("HUGGINGFACE_TOKEN")
     if not auth_token:
-        raise RuntimeError("Hugging Face token not found. Please set HUGGINGFACE_TOKEN environment variable.")
+        raise RuntimeError("Hugging Face token not configured. Please set it in the application settings.")
 
     try:
         if progress_callback:

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,15 +1,10 @@
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-import os
-from dotenv import load_dotenv
 
-# Load environment variables from a .env file
-load_dotenv()
+from .core.config import config
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://user:password@db/mydatabase")
-
-engine = create_engine(DATABASE_URL)
+engine = create_engine(config.database.url, echo=config.database.echo)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -1,10 +1,7 @@
 from celery import Celery
-import os
 import logging
-from dotenv import load_dotenv
 
-# Load environment variables from .env file
-load_dotenv()
+from .core.config import config
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
@@ -32,8 +29,8 @@ except Exception as e:
 
 # It's good practice to have a default for local development
 # The values from docker-compose.yml will be used when running in Docker
-celery_broker_url = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
-celery_result_backend = os.getenv("CELERY_RESULT_BACKEND", "redis://localhost:6379/0")
+celery_broker_url = config.celery.broker_url
+celery_result_backend = config.celery.result_backend
 
 # Initialize Celery
 celery_app = Celery(


### PR DESCRIPTION
## Summary
- centralize environment-driven settings for uploads, models, API keys, database, and celery in the core configuration module
- update chat, analysis, and diarization flows to resolve model defaults and credentials via the shared configuration helpers
- align provider factories, the database engine, and worker bootstrap with the standardized configuration accessors

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68dd1d83f24883269058be98780395d1