### PR TITLE
Refine NumPy compatibility shim

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,11 @@
+"""Application package initialisation."""
+
+from __future__ import annotations
+
+from ._compat import ensure_numpy_legacy_aliases as _ensure_numpy_legacy_aliases
+
+# Apply runtime compatibility shims before any submodules are imported. This is
+# idempotent and safe to call multiple times.
+_ensure_numpy_legacy_aliases()
+
+__all__ = []

--- a/backend/app/_compat.py
+++ b/backend/app/_compat.py
@@ -1,0 +1,44 @@
+"""Runtime compatibility helpers for optional dependencies."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+
+def ensure_numpy_legacy_aliases() -> None:
+    """Restore NumPy aliases that were removed in the 2.0 release.
+
+    Several third-party libraries (for example :mod:`pyannote.audio`) still
+    access camel-cased constants such as ``np.NaN`` that used to be available in
+    NumPy 1.x. When those libraries run on NumPy 2.0+, importing them raises an
+    :class:`AttributeError`. We proactively recreate the missing attributes so
+    that the rest of the application can continue working without pinning an old
+    NumPy version.
+    """
+
+    try:  # pragma: no cover - defensive guard for optional dependency
+        import numpy as np
+    except Exception:
+        # NumPy is optional at runtime. If it is not installed we simply skip
+        # the alias creation and let the caller fail with a clear error later.
+        return
+
+    alias_map: Dict[str, float] = {
+        "NaN": np.nan,
+        "NAN": np.nan,
+        "Inf": np.inf,
+        "PINF": np.inf,
+        "NINF": -np.inf,
+    }
+
+    for alias, value in alias_map.items():
+        if not hasattr(np, alias):
+            try:
+                setattr(np, alias, value)
+            except Exception:
+                # Setting attributes on the module should succeed, but we keep
+                # the guard to avoid breaking initialization if it does not.
+                pass
+
+
+__all__ = ["ensure_numpy_legacy_aliases"]

--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -1,0 +1,11 @@
+"""Core package initialisation and shared helpers."""
+
+from __future__ import annotations
+
+from .._compat import ensure_numpy_legacy_aliases as _ensure_numpy_legacy_aliases
+
+# Ensure compatibility shims are applied even when the core package is imported
+# directly. Calling the helper is idempotent so repeated imports are safe.
+_ensure_numpy_legacy_aliases()
+
+__all__ = []


### PR DESCRIPTION
## Summary
- add a reusable compatibility helper that restores removed NumPy aliases used by third-party libraries
- invoke the helper during app and core package initialisation to ensure shims are applied before imports

## Testing
- ✅ `cd backend && python - <<'PY'
try:
    import numpy as np
except ModuleNotFoundError:
    print("numpy not installed, skipping compatibility check")
else:
    import app  # triggers compatibility shims
    missing = [name for name in ("NaN", "NAN", "Inf", "PINF", "NINF") if not hasattr(np, name)]
    if missing:
        raise SystemExit(f"Missing expected aliases: {missing}")
    print("numpy legacy aliases available")
PY`


------
https://chatgpt.com/codex/tasks/task_e_68dd4d8d270883269819e37eab72bba2